### PR TITLE
Fix reaction process duplication

### DIFF
--- a/src/listeners/local_timeline.rs
+++ b/src/listeners/local_timeline.rs
@@ -26,6 +26,12 @@ impl<'a> EventListener for LocalTimelineListener<'a> {
 			info!("Skip update: Status posted by myself: {}", status.id());
 			return Ok(());
 		}
+
+		if status.mentions().iter().any(|m| m.acct() == self.me.acct()) {
+			info!("Skip update: Status mentioned to myself: {}", status.id());
+			return Ok(())
+		}
+
 		self.tx.send(Message::Status(status.clone())).map_err(|e| crate::Error::SendMessageError(Box::new(e)))
 	}
 }


### PR DESCRIPTION
Currently, the status mentioned to myself but not replied to myself is processed both Status and Notification.
In this case, process as Notification.