### PR TITLE
Consider status visibility

### DIFF
--- a/src/features/announcement/contents.rs
+++ b/src/features/announcement/contents.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration as StdDuration;
 use chrono::{ DateTime, Duration, Local, NaiveTime };
+use mastors::entities::Visibility;
 use serde::Deserialize;
 use crate::{
 	Error,
@@ -65,7 +66,12 @@ impl ContentsWorker {
 				.join("\n\n");
 
 			if !text.is_empty() {
-				tx.send(Message::Status{ text, mention: None, in_reply_to_id: None}).unwrap();
+				tx.send(Message::Status{
+					text,
+					mention: None,
+					visibility: Visibility::Public,
+					in_reply_to_id: None
+				}).unwrap();
 			}
 
 			// Prevent runaway due to time error

--- a/src/features/announcement/feeds.rs
+++ b/src/features/announcement/feeds.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 use feed_rs::model::Entry as FeedEntry;
+use mastors::entities::Visibility;
 use regex::Regex;
 use reqwest::blocking::Client;
 use serde::Deserialize;
@@ -57,6 +58,7 @@ impl FeedsWorker {
 						tx.send(Message::Status{
 							text: entry.build_text(),
 							mention: None,
+							visibility: Visibility::Public,
 							in_reply_to_id: None
 						}).unwrap();
 

--- a/src/features/response/notification.rs
+++ b/src/features/response/notification.rs
@@ -44,6 +44,7 @@ impl NotificationProcessor {
 				tx.send(Message::Status{
 					text: self.config.followed_message.to_owned(),
 					mention: Some(notification.account().acct().to_owned()),
+					visibility: status.visibility(),
 					in_reply_to_id: Some(status.id().to_owned()),
 				}).unwrap();
 			} else if self.config.unfollow_regex.is_match(content) {
@@ -51,6 +52,7 @@ impl NotificationProcessor {
 				tx.send(Message::Status{
 					text: self.config.unfollowed_message.to_owned(),
 					mention: Some(notification.account().acct().to_owned()),
+					visibility: status.visibility(),
 					in_reply_to_id: Some(status.id().to_owned()),
 				}).unwrap();
 			}

--- a/src/features/response/status.rs
+++ b/src/features/response/status.rs
@@ -97,7 +97,8 @@ impl StatusProcessor {
 			tx.send(Message::Status {
 				text: response,
 				mention: Some(status.account().acct().to_owned()),
-				in_reply_to_id: if status.account().is_remote() {
+				visibility: status.visibility(),
+				in_reply_to_id: if status.account().is_remote() || !status.is_public() {
 					Some(status.id().to_owned())
 				} else {
 					None

--- a/src/message_processor.rs
+++ b/src/message_processor.rs
@@ -28,7 +28,7 @@ impl<'a> MessageProcessor<'a> {
 
 	pub fn process(&mut self, msg: Message) -> Result<()> {
 		match msg {
-			Message::Status{text, mention, in_reply_to_id} => self.status(text, mention, in_reply_to_id),
+			Message::Status{text, mention, visibility, in_reply_to_id} => self.status(text, mention, visibility, in_reply_to_id),
 			Message::Follow(id) => self.follow(id),
 			Message::Unfollow(id) => self.unfollow(id),
 			Message::Error(text, e) => {
@@ -42,6 +42,7 @@ impl<'a> MessageProcessor<'a> {
 		&mut self,
 		text: String,
 		mention: Option<String>,
+		visibility: Visibility,
 		in_reply_to_id: Option<String>
 	) -> Result<()> {
 		info!("Start posting a Status");
@@ -56,7 +57,8 @@ impl<'a> MessageProcessor<'a> {
 			None => text,
 		};
 
-		let post = statuses::post(self.conn, self.emojis.emojify(&text));
+		let post = statuses::post(self.conn, self.emojis.emojify(&text))
+			.visibility(visibility);
 
 		let post = match in_reply_to_id {
 			Some(id) => post.in_reply_to_id(id),
@@ -112,6 +114,7 @@ pub enum Message {
 	Status {
 		text: String,
 		mention: Option<String>,
+		visibility: Visibility,
 		in_reply_to_id: Option<String>,
 	},
 	Follow(Account),


### PR DESCRIPTION
- Change the visibility of the response status to be the same as the visibility of reply destination
- Change to set `in_reply_to_id` to response status if reply destination is not public